### PR TITLE
replace deprecated dependency gcloud:0.29.0 with updated google-cloud…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "google cloud"
   ],
   "dependencies": {
-    "gcloud": "^0.29.0"
+    "google-cloud": "^0.40.0"
   },
   "devDependencies": {
     "winston": "^2.1"

--- a/winston.gcl.js
+++ b/winston.gcl.js
@@ -17,7 +17,7 @@ var GoogleCloudLogging = winston.transports.GoogleCloudLogging = function (optio
   options.gcl_project_id = options.gcl_project_id || "";
   options.gcl_key_filename = options.gcl_key_filename || "";
   options.gcl_log_name = options.gcl_log_name || "";
-  var gcloud = require('gcloud')({
+  var gcloud = require('google-cloud')({
       projectId: options.gcl_project_id,
       keyFilename: options.gcl_key_filename
   });


### PR DESCRIPTION
…:0.40.0.

I tested it locally and verified that logs were still sent to GCloud logger with the new dependency.
