### PR TITLE
update gcl_resource to use new obj structure

### DIFF
--- a/winston.gcl.js
+++ b/winston.gcl.js
@@ -24,7 +24,9 @@ var GoogleCloudLogging = winston.transports.GoogleCloudLogging = function (optio
   });
 
   this.gcl_resource = {
-      type: 'global'
+      resource: {
+          type: 'global'
+      }
   };
 
   this.log_bucket = this.logging.log(options.gcl_log_name);


### PR DESCRIPTION
Hi there!

First off, thanks for the awesome module! Secondly, I think Google has updated their logging API just slightly in recent versions. It looks like the metadata you pass into the `log.entry(...)` method has changed, which causes this error to occur:
``` bash
./node_modules/protobufjs/dist/protobuf.js:2472
                            throw Error(this+"#"+keyOrObj+" is not a field: undefined");
                            ^

Error: .google.logging.v2.LogEntry#type is not a field: undefined
    at Error (native)
    at MessagePrototype.set (./node_modules/protobufjs/dist/protobuf.js:2472:35)
    at MessagePrototype.set (./node_modules/protobufjs/dist/protobuf.js:2466:38)
    at Message (./node_modules/protobufjs/dist/protobuf.js:2395:34)
    at ProtoBuf.Reflect.ElementPrototype.verifyValue (./node_modules/protobufjs/dist/protobuf.js:1909:28)
    at ProtoBuf.Reflect.FieldPrototype.verifyValue (./node_modules/protobufjs/dist/protobuf.js:3455:43)
    at MessagePrototype.set (./node_modules/protobufjs/dist/protobuf.js:2475:59)
    at MessagePrototype.set (./node_modules/protobufjs/dist/protobuf.js:2466:38)
    at Message (./node_modules/protobufjs/dist/protobuf.js:2395:34)
    at serialize (./node_modules/@google-cloud/common/node_modules/grpc/src/node/src/common.js:87:23)
```
This error is occurring on version 0.1.7 of the module.